### PR TITLE
fix(upload): wait for R2 public hostname to see the new key before re…

### DIFF
--- a/server/api/files/upload.post.ts
+++ b/server/api/files/upload.post.ts
@@ -3,6 +3,45 @@ import { getCfEnv } from '~/lib/cf-env'
 
 type FileInfo = { name: string; filename: string; data: Uint8Array; type: string }
 
+/**
+ * After R2.put resolves, the public hostname (`R2_PUBLIC_BASE_URL`,
+ * usually `pub-*.r2.dev` or a custom domain) can still 404 the new
+ * key for up to a few seconds. The client receives the upload
+ * response and immediately sets `<img src=getImgUrl(/upload/<key>)>`,
+ * which navigates to that public URL — and the browser sees the 404,
+ * which doesn't auto-retry.
+ *
+ * Poll HEAD against the public URL until it's reachable, with short
+ * back-off. Returns once the object is visible OR after the timeout
+ * budget. We return success even on timeout (the upload itself
+ * succeeded — better to let the client retry image load than to
+ * fail the whole flow).
+ */
+async function waitForR2Propagation(
+  publicBase: string | undefined,
+  key: string,
+): Promise<{ visible: boolean; waitedMs: number }> {
+  if (!publicBase) return { visible: true, waitedMs: 0 }
+  const start = Date.now()
+  // Total budget ≈ 6.2s in the worst case (200 + 400 + 800 + 1600 + 3200).
+  const delays = [0, 200, 400, 800, 1600, 3200]
+  for (const d of delays) {
+    if (d > 0) await new Promise((r) => setTimeout(r, d))
+    try {
+      const r = await fetch(`${publicBase}/${key}`, { method: 'HEAD' })
+      if (r.ok) return { visible: true, waitedMs: Date.now() - start }
+      // Anything other than 404 is "weird but reachable" — bail out
+      // and let the client deal with it; we don't want to spin
+      // through a 5xx outage.
+      if (r.status !== 404) return { visible: true, waitedMs: Date.now() - start }
+    } catch {
+      // Fetch threw — DNS hiccup, CORS, whatever. Retry on the
+      // next tick rather than failing.
+    }
+  }
+  return { visible: false, waitedMs: Date.now() - start }
+}
+
 export default defineEventHandler(async (event) => {
   const formData = await readMultipartFormData(event)
   if (!formData || formData.length === 0) {
@@ -26,7 +65,8 @@ export default defineEventHandler(async (event) => {
     }
   }
 
-  const uploads = getCfEnv(event).UPLOADS
+  const env = getCfEnv(event)
+  const uploads = env.UPLOADS
   if (!uploads) {
     return {
       success: false,
@@ -58,6 +98,26 @@ export default defineEventHandler(async (event) => {
       message: `上传文件失败: ${reason}`,
       filename: '',
     }
+  }
+
+  // R2 propagation guard — see waitForR2Propagation docstring above
+  // for why this exists. Read base URL from runtimeConfig (public
+  // side has the URL even when the worker env doesn't seed
+  // process.env).
+  const publicBase =
+    (env.R2_PUBLIC_BASE_URL as string | undefined)
+    || (useRuntimeConfig().public?.r2PublicBaseUrl as string | undefined)
+    || ''
+  const propagation = await waitForR2Propagation(
+    publicBase.replace(/\/+$/, ''),
+    key,
+  )
+  if (!propagation.visible) {
+    // Object is in the bucket; the public hostname just hasn't seen
+    // it yet. Log this so we can spot if our timeout is too tight.
+    console.log(
+      `R2 public propagation timeout (${propagation.waitedMs}ms) for ${key}`,
+    )
   }
 
   return {


### PR DESCRIPTION
…sponding

R2.put() resolves as soon as the object lands in the bucket, but the public hostname (`R2_PUBLIC_BASE_URL`, typically pub-*.r2.dev or a custom domain) can keep 404'ing the new key for up to a few seconds while propagation catches up. The client gets the upload success response, immediately sets `<img src=getImgUrl(/upload/<key>)>`, and the browser sees the 404 — which it does not auto-retry. Result: the just-uploaded image looks broken until the user reloads.

Add `waitForR2Propagation`: after the put resolves, HEAD the public URL with back-off (0/200/400/800/1600/3200ms ≈ 6s worst case) until the object is reachable. Return the success response as soon as it's visible, OR after the whole budget if propagation lags — uploads shouldn't fail because of a slow CDN edge. Times out are logged so we can spot if 6s is too tight in practice.

Reads `R2_PUBLIC_BASE_URL` from the CF env first (where the plane seeds it as a binding text value) and falls back to runtimeConfig (populated from `process.env` at build time). When neither is set the wait is skipped — there's no public URL to verify against.